### PR TITLE
(#7417) - spec compliant AbortController to fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "test-webpack": "bash bin/test-webpack.sh"
   },
   "dependencies": {
+    "abort-controller": "^3.0.0",
     "argsarray": "0.0.1",
     "buffer-from": "1.1.0",
     "clone-buffer": "1.0.0",
@@ -52,7 +53,7 @@
     "localstorage-down": "0.6.7",
     "ltgt": "2.2.1",
     "memdown": "1.2.4",
-    "node-fetch": "^2.0.0",
+    "node-fetch": "^2.3.0",
     "promise-polyfill": "7.1.2",
     "readable-stream": "1.0.33",
     "request": "2.87.0",

--- a/packages/node_modules/pouchdb-fetch/src/fetch-browser.js
+++ b/packages/node_modules/pouchdb-fetch/src/fetch-browser.js
@@ -1,10 +1,6 @@
 'use strict';
 
-// AbortController was introduced quite a while after fetch and
-// isnt required for PouchDB to function so polyfill if needed
-var a = (typeof AbortController !== 'undefined')
-    ? AbortController
-    : function () { return {abort: function () {}}; };
+import a from 'abort-controller';
 
 var f = fetch;
 var h = Headers;

--- a/packages/node_modules/pouchdb-fetch/src/fetch.js
+++ b/packages/node_modules/pouchdb-fetch/src/fetch.js
@@ -1,14 +1,9 @@
 'use strict';
 
 import nodeFetch, {Headers} from 'node-fetch';
+import AbortController from 'abort-controller';
 import fetchCookie from 'fetch-cookie';
 
 var fetch = fetchCookie(nodeFetch);
-
-/* We can fake the abort, the http adapter keeps track
-   of ignoring the result */
-function AbortController() {
-  return {abort: function () {}};
-}
 
 export {fetch, Headers, AbortController};


### PR DESCRIPTION
Now that node-fetch has true support for abort signals, use a WHATWG spec compliant AbortController implementation.